### PR TITLE
ci: validate manifests with kustomize build + kubeconform

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,37 @@
+name: validate
+
+# Pre-merge guard: render and schema-validate every manifest before Flux ever
+# sees it, so a broken kustomization or bad CR fails here instead of silently
+# stalling reconciliation on the live cluster.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      KUSTOMIZE_VERSION: "5.4.3"
+      KUBECONFORM_VERSION: "0.6.7"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install kustomize
+        run: |
+          curl -fsSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin kustomize
+
+      - name: Install kubeconform
+        run: |
+          curl -fsSL "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin kubeconform
+
+      - name: Validate manifests
+        run: ./scripts/validate.sh

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Validate every manifest and kustomize overlay in this repo against its JSON
+# schema, mirroring what Flux's kustomize-controller does before it applies.
+#
+# Three passes:
+#   1. kubeconform the loose Flux Kustomization/GitRepository CRs under
+#      ./clusters/<cluster>/ that are applied by `flux bootstrap`, not built by
+#      kustomize.
+#   2. `kustomize build` every directory that owns a kustomization.yaml and pipe
+#      the rendered output through kubeconform.
+#
+# Schemas: the Kubernetes defaults, the Flux CRD schemas (downloaded below), and
+# the community CRDs-catalog for everything else (Istio, Gateway API, Karpenter,
+# kro). Anything still unknown is skipped via -ignore-missing-schemas rather
+# than failing the build.
+#
+# Requires: kustomize, kubeconform, curl, tar.
+
+set -o errexit
+set -o pipefail
+
+# mirror kustomize-controller build options
+kustomize_flags=("--load-restrictor=LoadRestrictionsNone")
+kustomize_config="kustomization.yaml"
+
+# Skip Secrets: they're applied out-of-band (Proxmox creds, k3s join token) and
+# never live in git, so there's nothing here to validate.
+kubeconform_flags=(
+  "-strict"
+  "-ignore-missing-schemas"
+  "-skip=Secret"
+  "-schema-location" "default"
+  "-schema-location" "/tmp/flux-crd-schemas/master-standalone-strict"
+  "-schema-location" "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+  "-verbose"
+)
+
+echo "INFO - Downloading Flux OpenAPI schemas"
+mkdir -p /tmp/flux-crd-schemas/master-standalone-strict
+curl -fsSL https://github.com/fluxcd/flux2/releases/latest/download/crd-schemas.tar.gz | \
+  tar zxf - -C /tmp/flux-crd-schemas/master-standalone-strict
+
+echo "INFO - Validating cluster Flux resources"
+find ./clusters -maxdepth 2 -type f -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file; do
+  echo "INFO - Validating ${file}"
+  kubeconform "${kubeconform_flags[@]}" "${file}"
+done
+
+echo "INFO - Validating kustomizations"
+find . -type f -name "${kustomize_config}" -print0 | while IFS= read -r -d $'\0' file; do
+  dir="${file%${kustomize_config}}"
+  echo "INFO - Validating kustomization ${dir}"
+  kustomize build "${dir}" "${kustomize_flags[@]}" | kubeconform "${kubeconform_flags[@]}"
+done
+
+echo "INFO - All manifests valid"


### PR DESCRIPTION
Adds a pre-merge `validate` workflow so a broken kustomization or malformed manifest fails in CI instead of silently stalling Flux reconciliation on the live cluster.

## What it does

`scripts/validate.sh` mirrors what kustomize-controller does before apply:

1. **kubeconform** the loose Flux CRs under `clusters/<cluster>/` (the `Kustomization`/`GitRepository` resources applied by `flux bootstrap`, not built by kustomize).
2. **`kustomize build`** every directory that owns a `kustomization.yaml` and pipe the rendered output through kubeconform.

Schemas: Kubernetes defaults + the Flux CRD schemas + the community [CRDs-catalog](https://github.com/datreeio/CRDs-catalog). Anything still unknown (Istio/Gateway API/kro/Proxmox CRDs) is skipped via `-ignore-missing-schemas`; Secrets are skipped since they're applied out-of-band and never in git.

The workflow (`.github/workflows/validate.yaml`) runs on every PR and on push to `main`, installing pinned kustomize and kubeconform.

## Verified

Ran `scripts/validate.sh` locally against the current tree — all manifests render and validate, only the expected CRD/Secret schemas skipped (the Karpenter `NodePool` validates against the catalog). 

Closes the "Add manifest validation CI" item.