### PR TITLE
trim: drop dex-server and notifications-controller from ArgoCD install

### DIFF
--- a/clusters/pez-k8s/argocd/delete-dex-deployment.yaml
+++ b/clusters/pez-k8s/argocd/delete-dex-deployment.yaml
@@ -1,0 +1,5 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-dex-server
+$patch: delete

--- a/clusters/pez-k8s/argocd/delete-dex-networkpolicy.yaml
+++ b/clusters/pez-k8s/argocd/delete-dex-networkpolicy.yaml
@@ -1,0 +1,5 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: argocd-dex-server-network-policy
+$patch: delete

--- a/clusters/pez-k8s/argocd/delete-dex-role.yaml
+++ b/clusters/pez-k8s/argocd/delete-dex-role.yaml
@@ -1,0 +1,5 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-dex-server
+$patch: delete

--- a/clusters/pez-k8s/argocd/delete-dex-rolebinding.yaml
+++ b/clusters/pez-k8s/argocd/delete-dex-rolebinding.yaml
@@ -1,0 +1,5 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-dex-server
+$patch: delete

--- a/clusters/pez-k8s/argocd/delete-dex-service.yaml
+++ b/clusters/pez-k8s/argocd/delete-dex-service.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-dex-server
+$patch: delete

--- a/clusters/pez-k8s/argocd/delete-dex-serviceaccount.yaml
+++ b/clusters/pez-k8s/argocd/delete-dex-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-dex-server
+$patch: delete

--- a/clusters/pez-k8s/argocd/delete-notifications-configmap.yaml
+++ b/clusters/pez-k8s/argocd/delete-notifications-configmap.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+$patch: delete

--- a/clusters/pez-k8s/argocd/delete-notifications-deployment.yaml
+++ b/clusters/pez-k8s/argocd/delete-notifications-deployment.yaml
@@ -1,0 +1,5 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-notifications-controller
+$patch: delete

--- a/clusters/pez-k8s/argocd/delete-notifications-networkpolicy.yaml
+++ b/clusters/pez-k8s/argocd/delete-notifications-networkpolicy.yaml
@@ -1,0 +1,5 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: argocd-notifications-controller-network-policy
+$patch: delete

--- a/clusters/pez-k8s/argocd/delete-notifications-role.yaml
+++ b/clusters/pez-k8s/argocd/delete-notifications-role.yaml
@@ -1,0 +1,5 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-notifications-controller
+$patch: delete

--- a/clusters/pez-k8s/argocd/delete-notifications-rolebinding.yaml
+++ b/clusters/pez-k8s/argocd/delete-notifications-rolebinding.yaml
@@ -1,0 +1,5 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-notifications-controller
+$patch: delete

--- a/clusters/pez-k8s/argocd/delete-notifications-secret.yaml
+++ b/clusters/pez-k8s/argocd/delete-notifications-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-notifications-secret
+$patch: delete

--- a/clusters/pez-k8s/argocd/delete-notifications-service.yaml
+++ b/clusters/pez-k8s/argocd/delete-notifications-service.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-notifications-controller-metrics
+$patch: delete

--- a/clusters/pez-k8s/argocd/delete-notifications-serviceaccount.yaml
+++ b/clusters/pez-k8s/argocd/delete-notifications-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-notifications-controller
+$patch: delete

--- a/clusters/pez-k8s/argocd/kustomization.yaml
+++ b/clusters/pez-k8s/argocd/kustomization.yaml
@@ -28,3 +28,20 @@ patches:
   - path: delete-applicationset-deployment.yaml
   - path: delete-applicationset-networkpolicy.yaml
   - path: delete-applicationset-crd.yaml
+  # Same reasoning for dex (SSO, unused — we only use local admin login) and
+  # notifications (unused — no Notification configs). Every pod removed
+  # matters on this node's single vCPU.
+  - path: delete-dex-serviceaccount.yaml
+  - path: delete-dex-role.yaml
+  - path: delete-dex-rolebinding.yaml
+  - path: delete-dex-service.yaml
+  - path: delete-dex-deployment.yaml
+  - path: delete-dex-networkpolicy.yaml
+  - path: delete-notifications-serviceaccount.yaml
+  - path: delete-notifications-role.yaml
+  - path: delete-notifications-rolebinding.yaml
+  - path: delete-notifications-configmap.yaml
+  - path: delete-notifications-secret.yaml
+  - path: delete-notifications-service.yaml
+  - path: delete-notifications-deployment.yaml
+  - path: delete-notifications-networkpolicy.yaml


### PR DESCRIPTION
## Summary
- Follow-up to #10/#11, found during the live cutover: this cluster's control-plane node is a single vCPU that was already intermittently starving coredns/metrics-server before this migration. Adding ArgoCD's 6 pods pushed it further, and coredns started crash-looping (probe timeouts) enough to repeatedly break ArgoCD's own repo-server DNS lookups mid-sync.
- We don't use SSO (dex) or notifications (no Notification configs anywhere in this repo), so drop both controllers the same way ApplicationSet was dropped in #11. Cuts ArgoCD from 6 pods to 4.

## Test plan
- [x] `kustomize build clusters/pez-k8s/argocd` (pinned v5.4.3) builds cleanly: 38 objects, no dex/notifications objects, only benign leftover references (optional volume mounts, RBAC rules, NetworkPolicy selectors).
- [x] `scripts/validate.sh` passes locally end-to-end.
- [ ] `validate` CI green.