### PR TITLE
Widen Renovate's ArgoCD manager to all Application manifests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,12 +3,8 @@
   "extends": ["config:recommended"],
   "argocd": {
     "managerFilePatterns": [
-      "/^infrastructure/istio/base\\.yaml$/",
-      "/^infrastructure/istio/istiod\\.yaml$/",
-      "/^infrastructure/istio/cni\\.yaml$/",
-      "/^infrastructure/istio/ztunnel\\.yaml$/",
-      "/^infrastructure/sealed-secrets/sealed-secrets\\.yaml$/",
-      "/^infrastructure/clusters/base/k8s-monitoring\\.yaml$/"
+      "/^infrastructure/.*\\.yaml$/",
+      "/^clusters/.*\\.yaml$/"
     ]
   },
   "customManagers": [


### PR DESCRIPTION
The `argocd` manager's file list was enumerated by hand, so any Application added after the Renovate config went in was invisible to it.

That's not hypothetical - it's why the Istio ingress gateway is still on **1.30.2** while `base`, `istiod`, `cni` and `ztunnel` all moved to **1.30.3**: `infrastructure/clusters/base/ingressgateway.yaml` was never in the list. `infrastructure/nfs-csi/csi-driver-nfs.yaml` was missing for the same reason.

Swapped the six hardcoded paths for two globs over `infrastructure/` and `clusters/`, so Applications added later get picked up without anyone remembering to edit this file.

Coverage goes from 6 chart Applications to 8:

| File | Chart | Pinned |
|---|---|---|
| `infrastructure/clusters/base/ingressgateway.yaml` | gateway | 1.30.2 (**new**) |
| `infrastructure/nfs-csi/csi-driver-nfs.yaml` | csi-driver-nfs | 4.13.4 (**new**) |
| `infrastructure/istio/base.yaml` | base | 1.30.3 |
| `infrastructure/istio/istiod.yaml` | istiod | 1.30.3 |
| `infrastructure/istio/cni.yaml` | cni | 1.30.3 |
| `infrastructure/istio/ztunnel.yaml` | ztunnel | 1.30.3 |
| `infrastructure/clusters/base/k8s-monitoring.yaml` | k8s-monitoring | 4.3.0 |
| `infrastructure/sealed-secrets/sealed-secrets.yaml` | sealed-secrets | 2.19.1 |

Checked that the csi-driver-nfs chart repo serves a valid `index.yaml` (200, latest 4.13.4), so that entry resolves rather than just adding noise.

Validated with `renovate-config-validator` against Renovate 44.5.3 - clean. Note that a stale `npx` cache will happily run Renovate 37 instead, which predates `managerFilePatterns` (it was `fileMatch` until 41) and reports the whole file as invalid. Pin the version if you re-run it.

Expect a `gateway 1.30.2 -> 1.30.3` PR on the next Renovate run to close the skew.