### PR TITLE
Drop the dead Minecraft port from the Copenhagen gateway

### DIFF
--- a/infrastructure/clusters/base/shared-gateway.yaml
+++ b/infrastructure/clusters/base/shared-gateway.yaml
@@ -4,12 +4,12 @@ metadata:
   name: shared-gateway
   namespace: istio-system
   annotations:
-    # Must sync after istiod (wave 1, needed for TCP listener support) and
-    # istio-ingressgateway (wave 4, needed for the Service's ports incl.
-    # 25565). Argo gates each wave on the previous one's health, and a Gateway
-    # counts healthy only once its listeners are Programmed - so if this ever
-    # syncs at/before those waves, an unready listener (e.g. a new TCP one)
-    # can permanently block the whole app-of-apps sync.
+    # Must sync after istiod (wave 1, which programs this Gateway) and
+    # istio-ingressgateway (wave 4, which owns the Service this binds to via
+    # `addresses`). Argo gates each wave on the previous one's health, and a
+    # Gateway counts healthy only once its listeners are Programmed - so if
+    # this ever syncs at/before those waves, an unready listener can
+    # permanently block the whole app-of-apps sync.
     argocd.argoproj.io/sync-wave: "6"
 spec:
   gatewayClassName: istio

--- a/infrastructure/clusters/pez-copenhagen/kustomization.yaml
+++ b/infrastructure/clusters/pez-copenhagen/kustomization.yaml
@@ -28,16 +28,6 @@ patches:
       - op: replace
         path: /parameters/server
         value: 192.168.0.253
-  - target:
-      kind: Application
-      name: istio-ingressgateway
-    patch: |-
-      - op: add
-        path: /spec/source/helm/valuesObject/service/ports/-
-        value:
-          name: tcp-minecraft
-          port: 25565
-          targetPort: 25565
   # Must match region in the out-of-band karpenter-provider-proxmox secret.
   - target:
       kind: ProxmoxNodeClass


### PR DESCRIPTION
Removing the `tcp-minecraft` Service port patch from the Copenhagen overlay. It has been orphaned since the workload was deleted.

### Why it is dead

- The Minecraft workload was removed in `pez-k8s-apps` [`b539a5e`](https://github.com/RWejlgaard/pez-k8s-apps/commit/b539a5e), and `apps/minecraft/base/tcproute.yaml` went with it.
- `shared-gateway` only ever declares the `http` listener. There is no TCP listener and no `TCPRoute` or `TLSRoute` left in either repo, so istiod has nothing to program port 25565 from.
- So Copenhagen has been advertising 25565 on the ingress gateway Service with nothing behind it.

Nothing upstream depends on it either. Per `pez-infra` `docs/hosts/copenhagen-a.md`, the bare-metal Minecraft server was decommissioned when copenhagen-a was repaved as Proxmox, and the host no longer accepts direct game-client connections.

### Result

Copenhagen now renders the same three ports as London:

| | before | after |
|---|---|---|
| ports | status-port, http2, https, **tcp-minecraft** | status-port, http2, https |

### On the sync wave

Left `shared-gateway` on `sync-wave: "6"`. The ordering requirement survives the Minecraft removal: the Gateway still has to land after `istio-ingressgateway` (wave 4), whose Service it binds to via `addresses`, and a Gateway only counts healthy once its listeners are Programmed, so syncing early can still wedge the whole app-of-apps sync. Only the 25565-specific wording in the comment is gone.

### Verification

`scripts/validate.sh` passes locally. Confirmed the rendered Copenhagen overlay contains no reference to 25565, and that the London overlay is byte-identical to `main`.